### PR TITLE
config: re-enable Academicons

### DIFF
--- a/config/_default/params.toml
+++ b/config/_default/params.toml
@@ -288,3 +288,6 @@ plugins_js  = []
 [cms]
   # See https://sourcethemes.com/academic/docs/install/#install-with-web-browser
   netlify_cms = true
+
+[icon.pack]
+  ai = true  # Academicons icon pack https://jpswalsh.github.io/academicons/


### PR DESCRIPTION
This is required because of 42696869c1b628b0bb7ee33a27a65ac886c582e1 in Academic